### PR TITLE
Update GitHub Pages URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ npm run deploy
 
 This builds the application and publishes the `build/` directory to the `gh-pages` branch. After enabling GitHub Pages in the repository settings, your site will be available at:
 
-<https://terrenkur.github.io/frontend-site/>
+<https://terrenkur.github.io/>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://terrenkur.github.io/frontend-site",
+  "homepage": "https://terrenkur.github.io",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
## Summary
- configure the homepage to use the root GitHub Pages domain
- update the README with the new URL

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68779a35d1f083208952a0d00fc17103