### PR TITLE
Fix CORS for GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ npm run deploy
 This builds the application and publishes the `build/` directory to the `gh-pages` branch. After enabling GitHub Pages in the repository settings, your site will be available at:
 
 <https://terenkur.github.io/frontend-site/>
+
+If you deploy the FastAPI backend separately, ensure the CORS configuration
+includes this GitHub Pages domain. Otherwise the frontend won't be able to
+fetch data from the API.

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ app.add_middleware(
     allow_origins=[
         "https://frontend-site-production.up.railway.app",
         "http://localhost:3000",
+        "https://terenkur.github.io",
     ],
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],


### PR DESCRIPTION
## Summary
- allow `https://terenkur.github.io` in the FastAPI CORS configuration
- document that the backend must include the GitHub Pages domain in CORS settings

## Testing
- `npm test --silent`
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6877b1babb9083208c18ec702f6dfe31