### PR TITLE
Fix CORS fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ npm run deploy
 This builds the application and publishes the `build/` directory to the `gh-pages` branch. After enabling GitHub Pages in the repository settings, your site will be available at:
 
 <https://terenkur.github.io/frontend-site/>
+
+If you deploy the FastAPI backend separately, make sure CORS is configured
+properly. The default setup now allows requests from any origin, so adjust it
+to your needs if you require stricter access control.

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,11 +19,8 @@ security = HTTPBearer()
 # Enable CORS so the frontend can connect from other hosts
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "https://frontend-site-production.up.railway.app",
-        "http://localhost:3000",
-    ],
-    allow_credentials=True,
+    allow_origins=["*"],
+    allow_credentials=False,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["*"],
     expose_headers=["*"],

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,8 +9,7 @@ export const getAuthHeaders = (token: string | null): Record<string, string> => 
   
  return {
     "Content-Type": "application/json",
-    "Authorization": `Bearer ${token}`,
-    "Origin": "https://frontend-site-production.up.railway.app"
+    "Authorization": `Bearer ${token}`
   };
 };
 
@@ -95,8 +94,7 @@ export const fetchWheelSettings = async (token: string | null): Promise<WheelSet
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`
-      },
-      credentials: 'include'
+      }
     });
 
     if (!res.ok) {
@@ -121,8 +119,7 @@ export const updateWheelSettings = async (
   const res = await fetch(`${API}/wheel-settings`, {
     method: "PATCH",
     headers: getAuthHeaders(token),
-    body: JSON.stringify(settings),
-    credentials: "include"
+    body: JSON.stringify(settings)
   });
   
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- allow any origin for the FastAPI backend
- remove unused credentials option from API calls
- note new CORS behaviour in README

## Testing
- `npm test --silent`
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6877b1babb9083208c18ec702f6dfe31