### PR TITLE
Fix backend URL references

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,7 +20,6 @@ security = HTTPBearer()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        "https://frontend-site-production.up.railway.app",
         "http://localhost:3000",
         "https://terenkur.github.io",
     ],

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import {Game, WheelSettings } from './types'; // Добавляем этот импорт
 
-const API = process.env.REACT_APP_API_URL || "https://web-production-ec36f.up.railway.app";
+// Base URL for the backend API. Defaults to the local FastAPI server.
+const API = process.env.REACT_APP_API_URL || "http://localhost:8000";
 
 export const getAuthHeaders = (token: string | null): Record<string, string> => {
   if (!token) {


### PR DESCRIPTION
## Summary
- remove mention of Railway backend URL
- update CORS config

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68781548a1648320b123f0624e804192