### PR TITLE
Fix backend port for Render

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -158,4 +158,7 @@ async def wheel_settings_options():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    import os
+
+    port = int(os.environ.get("PORT", 8000))
+    uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- use `PORT` environment variable in `backend/main.py` so Render finds the correct port

## Testing
- `python backend/main.py` *(fails: `ModuleNotFoundError: No module named 'jose'`)*

------
https://chatgpt.com/codex/tasks/task_e_687825bb4f648320a079d4e0799f9108